### PR TITLE
Update vm.js with error indicating renderer

### DIFF
--- a/node_package/src/worker/vm.js
+++ b/node_package/src/worker/vm.js
@@ -18,7 +18,7 @@ let bundleFilePath;
  */
 function undefinedForExecLogging(functionName) {
   return `
-    console.error('${functionName} is not defined for renderer VM. Note babel-polyfill may call this.');
+    console.error('[ReactOnRails Renderer]: ${functionName} is not defined for VM. Note babel-polyfill may call this.');
     console.error(getStackTrace().join('\\n'));`;
 }
 


### PR DESCRIPTION
By having the error prefixed with ReactOnRails Renderer], we'll
know that the error is coming from the custom React on Rails Renderer.

We can do this for other errors.