### PR TITLE
Remove the rspec-dummy-app task from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,39 +274,6 @@ jobs:
       - store_artifacts:
           path: spec/dummy/yarn-error.log
 
-  # Test React on Rails Pro without the Node Renderer
-  rspec-dummy-app:
-    docker:
-      - image: *docker_image
-    steps:
-      - checkout
-      - run: *print-system-info
-      - restore_cache: *restore-package-gem-cache
-      - restore_cache: *restore-dummy-app-gem-cache
-      - restore_cache:
-          name: Restore cached webpack bundles for dummy app
-          key: v3-dummy-app-webpack-bundle-{{ .Revision }}
-      - restore_cache: *restore-dummy-app-node-modules-cache
-      - run: *install-dummy-app-ruby-gems
-      - run: *install-latest-chrome
-      - run:
-          name: Touch webpack bundles
-          command:  touch spec/dummy/public/webpack/test/*
-      - run:
-          name: Run rspec tests
-          command: |
-            cd spec/dummy && SERVER_RENDERER=ExecJS bundle exec rspec --format RspecJunitFormatter \
-                                               --out ~/rspec/rspec.xml \
-                                               --format documentation
-      - store_test_results:
-          path: ~/rspec
-      - store_artifacts:
-          path: spec/dummy/tmp/capybara
-      - store_artifacts:
-          path: spec/dummy/log/test.log
-      - store_artifacts:
-          path: spec/dummy/yarn-error.log
-
 workflows:
   version: 2
   build-and-test:
@@ -336,11 +303,6 @@ workflows:
             - install-package-ruby-gems
             - build-dummy-app-webpack-test-bundles
             - install-dummy-app-ruby-gems
-      - rspec-dummy-app:
-          requires:
-            - install-package-ruby-gems
-            - install-dummy-app-ruby-gems
-            - build-dummy-app-webpack-test-bundles
       - rspec-dummy-app-node-renderer:
           requires:
             - install-package-ruby-gems

--- a/spec/dummy/config/initializers/react_on_rails_pro.rb
+++ b/spec/dummy/config/initializers/react_on_rails_pro.rb
@@ -5,8 +5,7 @@ ReactOnRailsPro.configure do |config|
   # Get timing of server render calls
   config.tracing = true
 
-  # Used to turn off the NodeRenderer during on CI workflow
-  config.server_renderer = ENV["SERVER_RENDERER"].presence || "NodeRenderer"
+  config.server_renderer = "NodeRenderer"
 
   config.renderer_password = "myPassword1"
 


### PR DESCRIPTION
Removing testing of React on Rails Pro with ExecJS Rendering

Tests in this repo run against the NodeRenderer. The basic react_on_rails repo runs tests using ExecJS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails_pro/156)
<!-- Reviewable:end -->
