### PR TITLE
Cache key not stable between machines same deploy

### DIFF
--- a/lib/react_on_rails_pro/cache.rb
+++ b/lib/react_on_rails_pro/cache.rb
@@ -51,7 +51,8 @@ module ReactOnRailsPro
         return @serializer_checksum if @serializer_checksum.present? && !Rails.env.development?
         return nil unless ReactOnRailsPro.configuration.serializer_globs.present?
 
-        serializer_files = Dir.glob(ReactOnRailsPro.configuration.serializer_globs)
+        # NOTE: Dir.glob is not stable between machines, even with same OS. So we must sort.
+        serializer_files = Dir.glob(ReactOnRailsPro.configuration.serializer_globs).sort
         digest = Digest::MD5.new
         serializer_files.each { |f| digest.file(f) }
         @serializer_checksum = digest.hexdigest


### PR DESCRIPTION
Dir.glob is not stable between machines, even with same OS.
So we must sort.

Currently, when Heroku has many dynos, we can get differently ordered results Dir.glob.

While it's known that Dir.glob ordering would be different on different OS versions, different
orders on the same OS was unexpected.

The original implementation of this came from this comment:
https://github.com/shakacode/react_on_rails/issues/39#issuecomment-143472325

```ruby
    def serializer_files
      Dir.glob(Rails.root.join('app/serializers/**/*.rb'))
    end
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails_pro/159)
<!-- Reviewable:end -->
