### PR TITLE
fix "Errno::EISDIR: Is a directory @ io_fread - "

### DIFF
--- a/lib/react_on_rails_pro/utils.rb
+++ b/lib/react_on_rails_pro/utils.rb
@@ -18,18 +18,6 @@ module ReactOnRailsPro
       ReactOnRailsPro::Request.upload_assets
     end
 
-    def self.digest_file_or_directory(file, digest)
-      # Dir.glob distinguishes files/directories by extension presense.
-      # Most of the paths with extensions are files, but sometimes there are directories with extensions.
-      # That's why this function is recoursive.
-      if File.directory?(file)
-        files = Dir.glob("#{file}/*").uniq.sort!
-        files.each { |f| self.digest_file_or_directory(f, digest) }
-      else
-        digest.file(file)
-      end
-    end
-
     # takes an array of globs & returns a md5 hash
     def self.digest_of_globs(globs)
       # NOTE: Dir.glob is not stable between machines, even with same OS. So we must sort.
@@ -38,7 +26,7 @@ module ReactOnRailsPro
       # We've tested it to make sure that it adds less than a second even in the case of thousands of files
       files = Dir.glob(globs).uniq.sort!
       digest = Digest::MD5.new
-      files.each { |f| self.digest_file_or_directory(f, digest) }
+      files.each { |f| digest.file(f) unless File.directory?(f) }
       digest.hexdigest
     end
 


### PR DESCRIPTION
The function crashes when encountering directories matching `globs`
for example `node_modules/@csstools/normalize.css` is a directory not a `css` file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails_pro/177)
<!-- Reviewable:end -->
