### PR TITLE
Request protocol undefined does not match installed renderer protocol 1.0.0 for version 2.3.0 => better logging

### DIFF
--- a/packages/node-renderer/src/worker/checkProtocolVersionHandler.js
+++ b/packages/node-renderer/src/worker/checkProtocolVersionHandler.js
@@ -9,7 +9,7 @@ module.exports = function checkProtocolVersion(req) {
     return {
       headers: { 'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate' },
       status: 412,
-      data: `Unsupported renderer protocol version, request protocol ${req.body.protocolVersion} ${!req.body.protocolVersion && `with body ${req.body}`} does not
+      data: `Unsupported renderer protocol version ${req.body.protocolVersion ? `request protocol ${req.body.protocolVersion}` : `MISSING with body ${req.body}`} does not
 match installed renderer protocol ${packageJson.protocolVersion} for version ${packageJson.version}.
 Update either the renderer or the Rails server`,
     };


### PR DESCRIPTION
See issue: https://github.com/shakacode/react_on_rails_pro/issues/251.

Better logging.