### PR TITLE
Replace use of utc_timestamp with Utils.bundle_hash

### DIFF
--- a/lib/react_on_rails_pro/server_rendering_pool/node_rendering_pool.rb
+++ b/lib/react_on_rails_pro/server_rendering_pool/node_rendering_pool.rb
@@ -17,9 +17,7 @@ module ReactOnRailsPro
           # Resetting the pool for server bundle modifications is accomplished by changing the mtime
           # of the server bundle in the request to the remote rendering server.
           # In non-development mode, we don't need to re-read this value.
-          if @bundle_hash.present? && !ReactOnRails.configuration.development_mode
-            return @bundle_hash
-          end
+          return @bundle_hash if @bundle_hash.present? && !ReactOnRails.configuration.development_mode
 
           @bundle_hash = ReactOnRailsPro::Utils.bundle_hash
         end


### PR DESCRIPTION
This should address issues where the mtime of a file changes due to slug deployment on Platforms such as Heroku.

Fixes #268. 