### PR TITLE
Make asset paths in PrepareNodeRenderBundles relative too

### DIFF
--- a/lib/react_on_rails_pro/prepare_node_renderer_bundles.rb
+++ b/lib/react_on_rails_pro/prepare_node_renderer_bundles.rb
@@ -6,7 +6,13 @@ module ReactOnRailsPro
   class PrepareNodeRenderBundles
     extend FileUtils
 
-    # rubocop:disable Metrics/AbcSize
+    def self.make_relative_symlink(source, destination)
+      File.delete(destination) if File.exist?(destination)
+      relative_source_path = Pathname.new(source).relative_path_from(Pathname.new(destination).dirname)
+      File.symlink(relative_source_path, destination)
+      puts "[ReactOnRailsPro] Symlinked #{relative_source_path} to #{destination}"
+    end
+
     def self.call
       # TODO: temporarily hardcoding tmp/bundles directory. renderer and rails should read from a Yaml file
       src_bundle_path = ReactOnRails::Utils.server_bundle_js_file_path
@@ -16,10 +22,7 @@ module ReactOnRailsPro
       puts "[ReactOnRailsPro] Symlinking assets to local node-renderer, path #{dest_path}"
       mkdir_p(dest_path)
 
-      File.delete(bundle_dest_path) if File.exist?(bundle_dest_path)
-      relative_source_path = Pathname.new(src_bundle_path).relative_path_from(Pathname.new(bundle_dest_path).dirname)
-      symlink(relative_source_path, bundle_dest_path)
-      puts "[ReactOnRailsPro] Symlinked #{relative_source_path} to #{bundle_dest_path}"
+      make_relative_symlink(src_bundle_path, bundle_dest_path)
 
       return unless ReactOnRailsPro.configuration.assets_to_copy.present?
 
@@ -27,11 +30,8 @@ module ReactOnRailsPro
         raise ReactOnRails::Error, "Asset not found #{asset_path}" unless File.exist?(asset_path)
 
         destination_full_path = File.join(dest_path, asset_path.basename.to_s)
-        File.delete(destination_full_path) if File.exist?(destination_full_path)
-        symlink(asset_path, destination_full_path)
-        puts "[ReactOnRailsPro] Symlinked #{asset_path} to #{destination_full_path}"
+        make_relative_symlink(asset_path, destination_full_path)
       end
     end
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -38,7 +38,7 @@ Before this command can be run:
 //npm.pkg.github.com/:_authToken=<TOKEN>
 always-auth=true
 ```
-3. You would create or edit a ~/.gem/credentials to include the following, replacing TOKEN with your personal access token.
+3. Create or edit a ~/.gem/credentials to include the following, replacing TOKEN with your personal access token.
 
 ---
 :github: Bearer TOKEN

--- a/spec/dummy/spec/prepare_node_renderer_bundles_spec.rb
+++ b/spec/dummy/spec/prepare_node_renderer_bundles_spec.rb
@@ -8,8 +8,8 @@ describe ReactOnRailsPro::PrepareNodeRenderBundles do # rubocop:disable RSpec/Fi
   let(:fixture_path) { File.expand_path("./spec/fixtures/#{asset_filename}") }
   let(:fixture_path2) { File.expand_path("./spec/fixtures/#{asset_filename2}") }
   let(:non_exist_fixture_path) { File.expand_path("./spec/fixtures/sample99.json") }
-  let(:asset_path_expanded) { Rails.root.join(".node-renderer-bundles", asset_filename) }
-  let(:asset_path_expanded2) { Rails.root.join(".node-renderer-bundles", asset_filename2) }
+  let(:asset_path_expanded) { path_in_bundles_folder(asset_filename) }
+  let(:asset_path_expanded2) { path_in_bundles_folder(asset_filename2) }
 
   before do
     dbl_configuration = instance_double("Configuration",
@@ -18,8 +18,8 @@ describe ReactOnRailsPro::PrepareNodeRenderBundles do # rubocop:disable RSpec/Fi
                                         renderer_url: "http://localhost:3800",
                                         renderer_request_retry_limit: 5,
                                         assets_to_copy: [
-                                          Rails.root.join("public", "webpack", "production", "loadable-stats2.json"),
-                                          Rails.root.join("public", "webpack", "production", "loadable-stats3.json")
+                                          path_in_webpack_folder(asset_filename),
+                                          path_in_webpack_folder(asset_filename2)
                                         ])
     allow(ReactOnRailsPro).to receive(:configuration).and_return(dbl_configuration)
     FileUtils.mkdir_p(Rails.root.join("public", "webpack", "production"))
@@ -29,8 +29,8 @@ describe ReactOnRailsPro::PrepareNodeRenderBundles do # rubocop:disable RSpec/Fi
 
   context("when assets exist") do
     before do
-      FileUtils.cp(fixture_path, Rails.root.join("public", "webpack", "production", asset_filename))
-      FileUtils.cp(fixture_path2, Rails.root.join("public", "webpack", "production", asset_filename2))
+      FileUtils.cp(fixture_path, path_in_webpack_folder(asset_filename))
+      FileUtils.cp(fixture_path2, path_in_webpack_folder(asset_filename2))
     end
 
     it "copying asset to public folder" do
@@ -39,12 +39,14 @@ describe ReactOnRailsPro::PrepareNodeRenderBundles do # rubocop:disable RSpec/Fi
       described_class.call
       expect(asset_exist_on_renderer?(asset_filename)).to eq(true)
       expect(asset_exist_on_renderer?(asset_filename2)).to eq(true)
+      expect(Pathname.new(File.readlink(asset_path_expanded)).relative?).to eq(true)
+      expect(File.realpath(asset_path_expanded)).to eq(path_in_webpack_folder(asset_filename).to_s)
     end
   end
 
   context("when assets don't exist") do
     it "prints warning if asset not found" do
-      first_asset_path = Rails.root.join("public", "webpack", "production", asset_filename)
+      first_asset_path = path_in_webpack_folder(asset_filename)
       File.delete(first_asset_path) if File.exist?(first_asset_path)
       expect do
         described_class.call
@@ -54,7 +56,15 @@ describe ReactOnRailsPro::PrepareNodeRenderBundles do # rubocop:disable RSpec/Fi
     end
   end
 
+  def path_in_bundles_folder(filename)
+    Rails.root.join(".node-renderer-bundles", filename)
+  end
+
+  def path_in_webpack_folder(filename)
+    Rails.root.join("public", "webpack", "production", filename)
+  end
+
   def asset_exist_on_renderer?(filename)
-    File.exist?(Rails.root.join(".node-renderer-bundles", filename))
+    File.exist?(path_in_bundles_folder(filename))
   end
 end


### PR DESCRIPTION
The symlink to the bundle itself was made relative in #231, but asset symlinks remained absolute. This makes them relative too.

Fixes #272