### PR TITLE
Require RoR error in RoRP error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ You can find the **package** version numbers from this repo's tags and below in 
 ## [Unreleased]
 *Add changes in master not yet tagged.*
 
+### Fixed
+- Fix possible `uninitialized constant ReactOnRails (NameError)` in `lib/react_on_rails_pro/error.rb:4`. [PR 277](https://github.com/shakacode/react_on_rails_pro/pull/273) by [alexeyr](https://github.com/alexeyr).
+
 ## [3.0.0] - 2022-07-07
 ### Fixed
-- Make asset paths in PrepareNodeRenderBundles relative too. The symlink to the bundle itself was made relative in #231, but asset symlinks remained absolute. This makes them relative too. Fixes #272. [PR 273](https://github.com/shakacode/react_on_rails_pro/pull/273) by [alexeyr-ci1](https://github.com/alexeyr-ci1).
+- Make asset paths in PrepareNodeRenderBundles relative too. The symlink to the bundle itself was made relative in #231, but asset symlinks remained absolute. This makes them relative too. Fixes #272. [PR 273](https://github.com/shakacode/react_on_rails_pro/pull/273) by [alexeyr](https://github.com/alexeyr).
 
 ## [3.0.0-rc.4] - 2022-06-28
 ### Fixed

--- a/lib/react_on_rails_pro/error.rb
+++ b/lib/react_on_rails_pro/error.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "react_on_rails/error"
+
 module ReactOnRailsPro
   class Error < ::ReactOnRails::Error
   end


### PR DESCRIPTION
`react_on_rails_pro/error` could accidentally be loaded before `react_on_rails/error`, which it uses, resulting in

    .../gems/react_on_rails_pro-3.0.0/lib/react_on_rails_pro/error.rb:4:in `<module:ReactOnRailsPro>': uninitialized constant ReactOnRails (NameError)