### PR TITLE
Remove the dash from the procfile process name

### DIFF
--- a/docs/node-renderer/heroku.md
+++ b/docs/node-renderer/heroku.md
@@ -2,7 +2,7 @@
 
 Most React on Rails Pro installations of the Node SSR Renderer will deploy the Rails and Renderer
 instances on the same server. This technique results in better performance since it avoids network
-latency. 
+latency.
 
 Scroll down if you want to have different servers.
 
@@ -24,7 +24,7 @@ web: bin/runsvdir-dyno
 
 ```
 puma: bundle exec puma -C config/puma.rb
-node-renderer: bin/node-renderer
+renderer: bin/node-renderer
 ```
 
 ### bin/node-renderer
@@ -52,7 +52,7 @@ If you're using the default tmp/bundles subdirectory for the node-renderer, you 
 ENV value for `RENDERER_BUNDLE_PATH`. Otherwise, please set this ENV value so the files get copied
 to the right place.
 
-Then you can use the rake task: `react_on_rails_pro:pre_stage_bundle_for_node_renderer`. 
+Then you can use the rake task: `react_on_rails_pro:pre_stage_bundle_for_node_renderer`.
 
 You might do something like this:
 
@@ -82,7 +82,7 @@ Errno::EADDRINUSE: Address already in use - bind(2) for "0.0.0.0" port 21752
 ### Deploy Node renderer to Heroku
 
 1. Create your **Heroku** app with **Node.js** buildpack, say `renderer-test.herokuapp.com`.
-2. In your JS configuration file or 
+2. In your JS configuration file or
    1. If setting the port, ensure the port uses `process.env.PORT` so it will use port number provided by **Heroku** environment. The default is to use the env value RENDERER_PORT if available. (*TODO: Need to check on this*)
    2. Set password in your configuration to something like `process.env.RENDERER_PASSWORD` and configure the corresponding **ENV variable** on your **Heroku** dyno so the `config/initializers/react_on_rails_pro.rb` uses this value.
 3. Run deployment process (usually by pushing changes to **Git** repo associated with created **Heroku** app).
@@ -90,7 +90,7 @@ Errno::EADDRINUSE: Address already in use - bind(2) for "0.0.0.0" port 21752
 
 ### Deploy react_on_rails application to Heroku
 
-1. Create your **Heroku** app for `react_on_rails`. 
+1. Create your **Heroku** app for `react_on_rails`.
 2. Configure your app to communicate with renderer app you've created above. Put the following to your `initializers/react_on_rails_pro` (assuming you have **SSL** certificate uploaded to your renderer **Heroku** app or you use **Heroku** wildcard certificate under `*.herokuapp.com`) and configure corresponding **ENV variable** for the render_url and/or password on your **Heroku** dyno.
 3. Run deployment process (usually by pushing changes to **Git** repo associated with created **Heroku** app).
 4. Once deployment process is finished, all rendering requests form your `react_on_rails` app should be served by `<your-heroku-app>.herokuapp.com` app via **HTTPS**.


### PR DESCRIPTION
According to a client report, [Heroku does not allow dashes or underscores in their Procfile process names](https://devcenter.heroku.com/articles/procfile).

Any Procfile process with a dash or underscore in its name will be straight up ignored by Heroku.