### PR TITLE
WIP - Change rspec config for output path to tmp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ jobs:
           command: |
             bundle exec rspec spec/react_on_rails_pro
       - store_test_results:
-          path: ~/rspec
+          path: ./tmp/rspec
       - store_artifacts:
           path: log/test.log
 
@@ -255,10 +255,10 @@ jobs:
           name: Run rspec tests
           command: |
             cd spec/dummy && bundle exec rspec --format RspecJunitFormatter \
-                                               --out ../../tmp/rspec-output.xml \
+                                               --out ../../tmp/rspec/rspec.xml \
                                                --format documentation
       - store_test_results:
-          path: ~/rspec
+          path: ./tmp/rspec
       - store_artifacts:
           path: spec/dummy/tmp/screenshots
       - store_artifacts:

--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,4 @@
 --format RspecJunitFormatter
---out ./tmp/rspec-output.xml
+--out ./tmp/rspec/rspec.xml
 --format documentation
 --color


### PR DESCRIPTION
The current configuration for the RSpec output file causes the `~` directory to be created in the project root directory.

This PR changes this behavior, setting RSpec to save its output in the `tmp` directory, which is already ignored by `git`.