### PR TITLE
Use allow instead of stub for test

### DIFF
--- a/spec/react_on_rails_pro/utils_spec.rb
+++ b/spec/react_on_rails_pro/utils_spec.rb
@@ -131,7 +131,7 @@ module ReactOnRailsPro
         before do
           allow(ReactOnRailsPro.configuration)
             .to receive(:tracing).and_return(false)
-          Rails.stub(:logger).and_return(logger_mock)
+          allow(Rails).to receive(:logger).and_return(logger_mock)
         end
 
         it "does not log the time for the method execution" do


### PR DESCRIPTION
Addressing the following failures in our CI:

```
Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling the
syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead.
Called from /home/circleci/project/spec/react_on_rails_pro/utils_spec.rb:134:in `block
(4 levels) in <module:ReactOnRailsPro>'.
```

Fixes the CI failure in #353 and #354.