### PR TITLE
Create additionalContext option

### DIFF
--- a/docs/node-renderer/js-configuration.md
+++ b/docs/node-renderer/js-configuration.md
@@ -16,7 +16,11 @@ Here are the options available for the JavaScript renderer configuration object,
 1. **password** (default: `env.RENDERER_PASSWORD`) - Password expected to receive form **Rails client** to authenticate rendering requests. If no password set, no authentication will be required.
 1. **allWorkersRestartInterval** (default: `env.RENDERER_ALL_WORKERS_RESTART_INTERVAL`) - Interval in minutes between scheduled restarts of all cluster of workers. By default restarts are not enabled. If restarts are enabled, `delayBetweenIndividualWorkerRestarts` should also be set.
 1. **delayBetweenIndividualWorkerRestarts** (default: `env.RENDERER_DELAY_BETWEEN_INDIVIDUAL_WORKER_RESTARTS`) - Interval in minutes between individual worker restarts (when cluster restart is triggered). By default restarts are not enabled. If restarts are enabled, `allWorkersRestartInterval` should also be set.
-1. **supportModules** - (default: `env.RENDERER_SUPPORT_MODULES || null`) - Should be set to `true` to allow the server-bundle code to see require, exports, etc. `false` is like the ExecJS behavior.
+1. **supportModules** - (default: `env.RENDERER_SUPPORT_MODULES || null`) - If set to true, `supportModules` enables the server-bundle code to call a default set of NodeJS modules that get added to the VM context: { Buffer, process, setTimeout, setInterval, clearTimeout, clearInterval }.
+This option is required to equal `true` if you want to use loadable components
+Setting this value to false causes the NodeRenderer to behave like ExecJS
+1. **additionalContext** - (default: `null`) - additionalContext enables you to specify additional NodeJS modules to add to the VM context in addition to our supportModules defaults. Object shorthand notation may be used, but is not required.
+Example: { URL, URLSearchParams, Crypto }
 1. **honeybadgerApiKey** - (default: `env.HONEYBADGER_API_KEY`) - If you want errors on the Node Renderer to be sent to Honeybadger, set this value and add package `@honeybadger-io/js`.
 1. **sentryDsn**: - (default: `env.SENTRY_DSN || null`) - Enables server rendering errors catching with Sentry if the options is set. Add package `@sentry/node`.
 1. **sentryTracing** - (default: `env.SENTRY_TRACING || null`) - Should be set to `true` to enable adding trace context to the error. Requires **sentryDsn** to be set.

--- a/packages/node-renderer/src/shared/configBuilder.js
+++ b/packages/node-renderer/src/shared/configBuilder.js
@@ -50,9 +50,17 @@ const defaultConfig = {
   // Use directory DEFAULT_TMP_DIR if none provided
   bundlePath: env.RENDERER_BUNDLE_PATH || DEFAULT_TMP_DIR,
 
-  // supportModules should be set to true to allow the server-bundle code to see require, exports, etc.
-  // false is like the ExecJS behavior
+  // If set to true, `supportModules` enables the server-bundle code to call a default set of NodeJS modules
+  // that get added to the VM context: { Buffer, process, setTimeout, setInterval, clearTimeout, clearInterval }.
+  // This option is required to equal `true` if you want to use loadable components.
+  // Setting this value to false causes the NodeRenderer to behave like ExecJS
   supportModules: env.RENDERER_SUPPORT_MODULES || null,
+
+  // additionalContext enables you to specify additional NodeJS modules to add to the VM context in
+  // addition to our supportModules defaults.
+  // Object shorthand notation may be used, but is not required.
+  // Example: { URL, URLSearchParams, Crypto }
+  additionalContext: null,
 
   // Workers count defaults to number of CPUs minus 1
   workersCount:

--- a/packages/node-renderer/src/worker.js
+++ b/packages/node-renderer/src/worker.js
@@ -120,6 +120,7 @@ module.exports = function run(config) {
         return;
       }
 
+      // DO NOT REMOVE (REQUIRED FOR TIMEOUT TESTING)
       // if(TESTING_TIMEOUTS && getRandomInt(2) === 1) {
       //   console.log(
       //     'ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ');

--- a/packages/node-renderer/tests/vm.test.js
+++ b/packages/node-renderer/tests/vm.test.js
@@ -38,7 +38,7 @@ describe('buildVM and runInVM', () => {
       expect(result).toBeTruthy();
     });
 
-    test('available if supportModules disabled', async () => {
+    test('available if supportModules enabled', async () => {
       const config = getConfig();
       config.supportModules = true;
 
@@ -49,6 +49,27 @@ describe('buildVM and runInVM', () => {
       expect(result).toBeTruthy();
 
       result = await runInVM('typeof process !== "undefined"');
+      expect(result).toBeTruthy();
+    });
+  });
+
+  describe('additionalContext', () => {
+    test('not available if additionalContext not set', async () => {
+      await createUploadedBundleForTest();
+      await buildVM(uploadedBundlePathForTest());
+
+      const result = await runInVM('typeof testString === "undefined"');
+      expect(result).toBeTruthy();
+    });
+
+    test('available if additionalContext set', async () => {
+      const config = getConfig();
+      config.additionalContext = { testString: 'a string' };
+
+      await createUploadedBundleForTest();
+      await buildVM(uploadedBundlePathForTest());
+
+      const result = await runInVM('typeof testString !== "undefined"');
       expect(result).toBeTruthy();
     });
   });

--- a/spec/dummy/client/node-renderer.js
+++ b/spec/dummy/client/node-renderer.js
@@ -38,9 +38,10 @@ const config = {
 
   sentryTracesSampleRate: 1,
 
-  // supportModules should be set to true to allow the server-bundle code to see require, exports, etc.
-  // false is like the ExecJS behavior
-  // this option is required to equal `true` if you want to use loadable components
+  // If set to true, `supportModules` enables the server-bundle code to call a default set of NodeJS modules
+  // that get added to the VM context: { Buffer, process, setTimeout, setInterval, clearTimeout, clearInterval }.
+  // This option is required to equal `true` if you want to use loadable components.
+  // Setting this value to false causes the NodeRenderer to behave like ExecJS
   supportModules: true,
 
   // Required to use setTimeout, setInterval, & clearTimeout during server rendering


### PR DESCRIPTION
This PR creates an additionalContext option so that users can easily add additional NodeJS modules to the VM context.