### PR TITLE
Make `cache_data` visible to `integration_spec`

### DIFF
--- a/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -5,10 +5,6 @@ require "support/script_tag_utils"
 
 RequestDetails = Struct.new(:original_url, :env)
 
-def cache_data
-  Rails.cache.instance_variable_get(:@data)
-end
-
 describe ReactOnRailsProHelper, type: :helper do
   # In order to test the pro helper, we need to load the methods from the regular helper.
   # I couldn't see any easier way to do this.

--- a/spec/dummy/spec/support/cache.rb
+++ b/spec/dummy/spec/support/cache.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+def cache_data
+  Rails.cache.instance_variable_get(:@data)
+end


### PR DESCRIPTION
`spec/dummy/spec/system/integration_spec.rb` [uses `cache_data`](https://github.com/shakacode/react_on_rails_pro/blob/312c3f91aa6d6c829ece8f9e1a640d0cf29aa1bf/spec/dummy/spec/system/integration_spec.rb#L94) which was defined inside another spec and so couldn't be run on its own.