### PR TITLE
Freeze lockfiles in CI and in Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,12 +33,12 @@ aliases:
     name: Install Node modules with Yarn for renderer package
     command: |
       sudo yarn global add yalc
-      yarn install --no-progress --no-emoji
+      yarn install --frozen-lockfile --no-progress --no-emoji
 
   # Install/update Node modules for dummy app unless existing set of modules is satisfying Yarn.
   - &install-dummy-app-node-modules
     name: Install Node modules with Yarn for dummy app
-    command: cd spec/dummy && yarn install --no-progress --no-emoji
+    command: cd spec/dummy && yarn install --frozen-lockfile --no-progress --no-emoji
 
   # Install ruby gems unless existing set of gems is satisfying bundler.
   - &install-dummy-app-ruby-gems

--- a/.controlplane/Dockerfile
+++ b/.controlplane/Dockerfile
@@ -13,13 +13,14 @@ WORKDIR /app
 COPY Gemfile Gemfile.development_dependencies Gemfile.lock react_on_rails_pro.gemspec .
 COPY lib ./lib
 
+ENV BUNDLE_FROZEN=true
 RUN bundle config set without 'development test' && \
     bundle config set with 'staging production' && \
     bundle install --jobs=3 --retry=3
 
 # install node packages
 COPY package.json yarn.lock .
-RUN yarn install
+RUN yarn install --frozen-lockfile
 
 # pick necessary app files
 COPY spec/ ./spec
@@ -30,12 +31,13 @@ COPY rakelib/ ./rakelib
 
 WORKDIR /app/spec/dummy
 
+ENV BUNDLE_FROZEN=true
 RUN bundle config set without 'development test' && \
     bundle config set with 'staging production' && \
     bundle install --jobs=3 --retry=3
 
 RUN yarn global add yalc
-RUN yarn install
+RUN yarn install --frozen-lockfile
 
 ENV NODE_ENV=production
 ENV RAILS_ENV=production

--- a/rakelib/dummy_apps.rake
+++ b/rakelib/dummy_apps.rake
@@ -8,7 +8,7 @@ include ReactOnRailsPro::TaskHelpers
 
 namespace :dummy_app do
   task :yarn_install do
-    yarn_install_cmd = "yarn install --mutex network"
+    yarn_install_cmd = "yarn install --frozen-lockfile --mutex network"
     sh_in_dir(dummy_app_dir, yarn_install_cmd)
   end
 

--- a/rakelib/task_helpers.rb
+++ b/rakelib/task_helpers.rb
@@ -25,7 +25,7 @@ module ReactOnRailsPro
     end
 
     def bundle_install_in(dir)
-      sh_in_dir(dir, "bundle install")
+      sh_in_dir(dir, "BUNDLE_FROZEN=true bundle install")
     end
 
     # Runs bundle exec using that directory's Gemfile

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -28,6 +28,6 @@ fi
 if [ -f "Gemfile" ]; then
   echo "==> Installing gem dependencies…"
   bundle check --path vendor/gems 2>&1 >/dev/null || {
-    bundle install --path vendor/gems --quiet --without production
+    BUNDLE_FROZEN=true bundle install --path vendor/gems --quiet --without production
   }
 fi

--- a/spec/dummy/bin/setup
+++ b/spec/dummy/bin/setup
@@ -10,7 +10,7 @@ Dir.chdir APP_ROOT do
 
   puts "== Installing dependencies =="
   system "gem install bundler --conservative"
-  system "bundle check || bundle install"
+  system "bundle check || BUNDLE_FROZEN=true bundle install"
 
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")

--- a/spec/execjs-compatible-dummy/Dockerfile
+++ b/spec/execjs-compatible-dummy/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential git libvips pkg-config
 
 # Install application gems
+ENV BUNDLE_FROZEN=true
 COPY Gemfile Gemfile.lock ./
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \

--- a/spec/execjs-compatible-dummy/bin/setup
+++ b/spec/execjs-compatible-dummy/bin/setup
@@ -17,10 +17,10 @@ FileUtils.chdir APP_ROOT do
 
   puts "== Installing dependencies =="
   system! "gem install bundler --conservative"
-  system("bundle check") || system!("bundle install")
+  system("bundle check") || system!("BUNDLE_FROZEN=true bundle install")
 
   # Install JavaScript dependencies
-  system!("yarn install")
+  system!("yarn install --frozen-lockfile")
 
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")


### PR DESCRIPTION
Makes sure CI fails if `package.json` or gemfiles are changed and the corresponding lockfile is not updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced dependency installation processes for Ruby and Node.js, ensuring consistency with lockfiles.
  
- **Bug Fixes**
	- Improved reliability of dependency installations by enforcing the use of frozen lockfiles during the installation of gems and Node modules.

- **Documentation**
	- Updated scripts and configurations to reflect changes in dependency management practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->