### PR TITLE
Add Capybara screenshots for selenium_chrome_headless_with_logging

### DIFF
--- a/spec/dummy/spec/rails_helper.rb
+++ b/spec/dummy/spec/rails_helper.rb
@@ -138,6 +138,9 @@ RSpec.configure do |config|
 
   Capybara.save_path = Rails.root.join("tmp", "capybara")
   Capybara::Screenshot.prune_strategy = { keep: 10 }
+  Capybara::Screenshot.register_driver(:selenium_chrome_headless_with_logging) do |capybara_driver, path|
+    capybara_driver.browser.save_screenshot(path)
+  end
 
   # https://github.com/mattheworiordan/capybara-screenshot/issues/243#issuecomment-620423225
   config.retry_callback = proc do |ex|


### PR DESCRIPTION
Without this PR I see errors looking like
```
capybara-screenshot could not detect a screenshot driver for 'selenium_chrome_headless_with_logging'. Saving with default with unknown results.
WARN: Screenshot could not be saved. An exception is raised: #<NoMethodError: undefined method `render' for #<Capybara::Selenium::Driver:0x00007f4c65292710>>.
```
for some feature test failures. See https://app.circleci.com/pipelines/github/shakacode/react_on_rails_pro/1681/workflows/d64d79bf-ff2e-450a-8f83-8e8567b58511/jobs/17356?invite=true#step-117-5941_88 for an example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new screenshot driver for enhanced screenshot functionality during tests using the `selenium_chrome_headless_with_logging` driver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->