### PR TITLE
Default to pretty logging when `NODE_ENV` is not set

### DIFF
--- a/packages/node-renderer/src/shared/log.ts
+++ b/packages/node-renderer/src/shared/log.ts
@@ -3,7 +3,7 @@ import type { PrettyOptions } from 'pino-pretty';
 
 let pretty = false;
 
-if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
+if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test' || !process.env.NODE_ENV) {
   try {
     // eslint-disable-next-line global-require
     require('pino-pretty');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging capabilities by enabling pretty logging when `NODE_ENV` is not defined.
  
- **Bug Fixes**
	- Improved logging conditions to ensure appropriate logging in various environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->