### PR TITLE
Enable using the package as a Git dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ You can find the **package** version numbers from this repo's tags and below in 
 ## [Unreleased]
 *Add changes in master not yet tagged.*
 
+### Fixed
+- Enable use as a `git:` dependency. [PR 490](https://github.com/shakacode/react_on_rails_pro/pull/490) by [alexeyr-ci](https://github.com/alexeyr-ci).
 
 ## [4.0.0.rc.9] - 2024-12-05
 

--- a/package-scripts.yml
+++ b/package-scripts.yml
@@ -27,8 +27,23 @@ scripts:
     script: concurrently --prefix "[{name}]" --names "ESLINT, RUBOCOP, PRETTIER" -c "blue,yellow,magenta,orange" "nps eslint" "bundle exec rubocop" "nps format.listDifferent"
 
   build:
-    description: Build the project
-    script: echo "building the project" && rm -rf packages/node-renderer/dist && tsc --project packages/node-renderer/src
+    default:
+      description: Build the project
+      script: echo "building the project" && rm -rf packages/node-renderer/dist && tsc --project packages/node-renderer/src
+    prepack:
+      description: Build the project in the prepack/prepare scripts
+      # This is necessary when used as a Git dependency since we don't have the dist directory in the repo.
+      # Depending on the package manager, `prepack`, `prepare`, or both may be run.
+      # They may also be run when publishing or in other cases, so we want to cover all of them.
+      # 1. If the project is already built, do nothing;
+      # 2. Build the project but ignore TypeScript errors from missing devDependencies;
+      # 3. Check if the project is built now;
+      # 4. If it failed, print an error message (still follow https://docs.npmjs.com/cli/v8/using-npm/scripts#best-practices).
+      script: >
+        [ -f packages/node-renderer/dist/ReactOnRailsProNodeRenderer.js ] ||
+          (nps build >/dev/null 2>&1 || true) &&
+          [ -f packages/node-renderer/dist/ReactOnRailsProNodeRenderer.js ] ||
+          { echo 'Building @shakacode-tools/react-on-rails-pro-node-renderer seems to have failed!'; }
 
   clean:
     description: Clean the project

--- a/package.json
+++ b/package.json
@@ -108,6 +108,8 @@
   ],
   "scripts": {
     "test": "nps test",
+    "prepack": "nps build.prepack",
+    "prepare": "nps build.prepack",
     "prepublishOnly": "nps build",
     "start": "nps",
     "developing": "nps node-renderer.debug",


### PR DESCRIPTION
When I tried to use a Git branch of the Node Renderer in Popmenu, it failed because the package isn't built after downloading. This PR fixes the issue. It should work for all package managers consuming this package:

* npm runs both `prepare` and `prepack` (and I think prepack is the more recommended) for Git dependencies;
* Yarn v1 runs only `prepare`
* Yarn v2+ runs only `prepack`
* pnpm doesn't document it anywhere I could find, but probably still runs one of them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `prepack` script for enhanced build processes prior to packaging.
	- Added streaming server rendering support with new helper methods for improved performance and debugging.

- **Improvements**
	- Updated the `build` script to be categorized under `default`, maintaining its existing functionality while improving organization.
	- Enhanced error handling during server rendering with new configuration options.
	- Transitioned logging mechanism to Pino for better integration with Fastify.
	- Updated project to enable usage as a `git:` dependency.
	- Shifted dependencies from local paths to GitHub repository URLs for better version control.

- **Documentation**
	- Updated `CHANGELOG.md` to reflect recent changes and enhancements, including versioning updates and detailed modifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->