### PR TITLE
Change default Fastify log level to 'error'

### DIFF
--- a/packages/node-renderer/src/shared/configBuilder.ts
+++ b/packages/node-renderer/src/shared/configBuilder.ts
@@ -115,8 +115,8 @@ const defaultConfig: Config = {
   // Show only important messages by default
   logLevel: logLevel(env.RENDERER_LOG_LEVEL || DEFAULT_LOG_LEVEL),
 
-  // Do not log HTTP messages by default
-  logHttpLevel: logLevel(env.RENDERER_LOG_HTTP_LEVEL || 'silent'),
+  // Log only errors from Fastify by default
+  logHttpLevel: logLevel(env.RENDERER_LOG_HTTP_LEVEL || 'error'),
 
   bundlePath: env.RENDERER_BUNDLE_PATH || defaultBundlePath(),
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Updated default HTTP logging level from 'silent' to 'error', enabling more visibility into potential HTTP-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->