### PR TITLE
Fix apollo graphql examples

### DIFF
--- a/spec/dummy/app/controllers/graphql_controller.rb
+++ b/spec/dummy/app/controllers/graphql_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class GraphqlController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [:execute]
   def execute
     variables = prepare_variables(params[:variables])
     query = params[:query]

--- a/spec/dummy/client/node-renderer.js
+++ b/spec/dummy/client/node-renderer.js
@@ -55,7 +55,7 @@ const config = {
 
   // additionalContext enables you to specify additional NodeJS modules to add to the VM context in
   // addition to our supportModules defaults.
-  additionalContext: { URL, AbortController },
+  additionalContext: { URL, AbortController, queueMicrotask, },
 
   // Required to use setTimeout, setInterval, & clearTimeout during server rendering
   includeTimerPolyfills: false,


### PR DESCRIPTION
During my local test of #501, I discovered that both `/apollo_graphql` & `/lazy_apollo_graphql` were failing.

This PR fixes those examples.

I'll also be adding CI specs for one or both of these pages, if possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
	- Modified GraphQL controller to skip authenticity token verification for the execute action
- **Configuration**
	- Updated Node renderer context to include `queueMicrotask` function

<!-- end of auto-generated comment: release notes by coderabbit.ai -->