### PR TITLE
Update 4.0 release notes

### DIFF
--- a/docs/release-notes/4.0.md
+++ b/docs/release-notes/4.0.md
@@ -18,7 +18,8 @@ They shouldn't require any changes to your existing code or configuration.
 
 ## Breaking Changes
 
-* If you used Sentry or Honeybadger integrations for the Node renderer, remove the old configuration options starting with `sentry_` or `honeybadger_`, and follow the [Error Reporting and Tracing](../node-renderer/error-reporting-and-tracing.md) documentation.
+* If you used Sentry or Honeybadger integrations for the Node renderer, remove the old configuration options starting with `sentry` or `honeybadger`, and follow the [Error Reporting and Tracing](../node-renderer/error-reporting-and-tracing.md) documentation.
+* `includeTimerPolyfills` is renamed to `stubTimers`. The corresponding environment variable is `RENDERER_STUB_TIMERS` instead of `INCLUDE_TIMER_POLYFILLS`.
 
 ### Required dependency versions
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Updated configuration option naming for Sentry and Honeybadger integrations
  - Renamed configuration option `includeTimerPolyfills` to `stubTimers`
  - Updated corresponding environment variable from `INCLUDE_TIMER_POLYFILLS` to `RENDERER_STUB_TIMERS`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->