### PR TITLE
Retry on all errors except HTTPX::TimeoutError

### DIFF
--- a/lib/react_on_rails_pro/request.rb
+++ b/lib/react_on_rails_pro/request.rb
@@ -155,7 +155,11 @@ module ReactOnRailsPro
           # For persistent connections we want retries,
           # so the requests don't just fail if the other side closes the connection
           # https://honeyryderchuck.gitlab.io/httpx/wiki/Persistent
-          .plugin(:retries, max_retries: 1, retry_change_requests: true)
+          .plugin(:retries, max_retries: 1, retry_change_requests: true, retry_on: lambda { |res|
+            # Retrying on timeout errors is a bad idea: timeout often happen during high server load
+            # retrying in that case would increase server-load even further.
+            !res.error.is_a?(HTTPX::TimeoutError)
+          })
           .plugin(:stream)
           # See https://www.rubydoc.info/gems/httpx/1.3.3/HTTPX%2FOptions:initialize for the available options
           .with(


### PR DESCRIPTION
A fix for a flaky 500 error with the following call stack:
```
#<HTTP2::Error::ProtocolError: protocol error>
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/http-2-1.0.2/lib/http/2/connection.rb:815:in `connection_error'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/http-2-1.0.2/lib/http/2/connection.rb:519:in `connection_management'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/http-2-1.0.2/lib/http/2/connection.rb:269:in `receive'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/http-2-1.0.2/lib/http/2/client.rb:45:in `receive'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/http-2-1.0.2/lib/http/2/connection.rb:416:in `<<'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/connection/http2.rb:92:in `<<'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/connection.rb:410:in `block (3 levels) in consume'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/connection.rb:393:in `loop'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/connection.rb:393:in `block (2 levels) in consume'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/connection.rb:362:in `loop'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/connection.rb:362:in `block in consume'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/connection.rb:360:in `catch'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/connection.rb:360:in `consume'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/connection.rb:244:in `call'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/selector.rb:186:in `select_one'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/selector.rb:121:in `select'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/selector.rb:37:in `block in next_tick'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/selector.rb:29:in `catch'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/selector.rb:29:in `next_tick'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/session.rb:341:in `block (2 levels) in receive_requests'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/session.rb:341:in `catch'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/session.rb:341:in `block in receive_requests'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/session.rb:336:in `loop'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/session.rb:336:in `receive_requests'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/session.rb:311:in `send_requests'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/session.rb:108:in `request'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/plugins/stream.rb:104:in `request'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/httpx-1.4.0/lib/httpx/chainable.rb:10:in `post'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/react_on_rails_pro-4.0.0.rc.10/lib/react_on_rails_pro/request.rb:51:in `perform_request'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/react_on_rails_pro-4.0.0.rc.10/lib/react_on_rails_pro/request.rb:17:in `render_code'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/react_on_rails_pro-4.0.0.rc.10/lib/react_on_rails_pro/server_rendering_pool/node_rendering_pool.rb:52:in `eval_js'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/react_on_rails-14.1.1/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb:61:in `exec_server_render_js'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/react_on_rails_pro-4.0.0.rc.10/lib/react_on_rails_pro/server_rendering_pool/node_rendering_pool.rb:41:in `exec_server_render_js'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/react_on_rails_pro-4.0.0.rc.10/lib/react_on_rails_pro/server_rendering_pool/pro_rendering.rb:84:in `render_on_pool'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/react_on_rails_pro-4.0.0.rc.10/lib/react_on_rails_pro/server_rendering_pool/pro_rendering.rb:42:in `block in exec_server_render_js'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/react_on_rails_pro-4.0.0.rc.10/lib/react_on_rails_pro/utils.rb:104:in `with_trace'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/react_on_rails_pro-4.0.0.rc.10/lib/react_on_rails_pro/server_rendering_pool/pro_rendering.rb:20:in `exec_server_render_js'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/react_on_rails-14.1.1/lib/react_on_rails/server_rendering_pool.rb:22:in `server_render_js_with_console_logging'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/react_on_rails-14.1.1/lib/react_on_rails/helper.rb:629:in `server_rendered_react_component'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/react_on_rails-14.1.1/lib/react_on_rails/helper.rb:551:in `internal_react_component'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/react_on_rails-14.1.1/lib/react_on_rails/helper.rb:171:in `react_component_hash'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/react_on_rails_pro-4.0.0.rc.10/app/helpers/react_on_rails_pro_helper.rb:89:in `block (2 levels) in cached_react_component_hash'
server             | /home/romex/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/react_on_rails_pro-4.0.0.rc.10/app/helpers/react_on_rails_pro_helper.rb:18:in `block in fetch_react_component'

```

## Reproduction (Popmenu)
Disable caching and keep reloading a consumer-side page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection handling for timeout errors by preventing redundant retry attempts. This change reduces unnecessary server load during high-traffic periods, leading to more stable and efficient performance without altering the overall request management workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->