### PR TITLE
WIP Switch from lockfile to proper-lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@fastify/multipart": "^8.3.0 || ^9.0.1",
     "fastify": "^4.28.1 || ^5.1.0",
     "fs-extra": "^11.2.0",
-    "lockfile": "^1.0.4"
+    "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",
@@ -56,7 +56,7 @@
     "@tsconfig/node14": "^14.1.2",
     "@types/fs-extra": "^11.0.4",
     "@types/jest": "^29.5.12",
-    "@types/lockfile": "^1.0.4",
+    "@types/proper-lockfile": "^4.1.4",
     "@types/touch": "^3.1.5",
     "babel-jest": "^29.7.0",
     "concurrently": "^9.1.0",

--- a/packages/node-renderer/src/worker/handleRenderRequest.ts
+++ b/packages/node-renderer/src/worker/handleRenderRequest.ts
@@ -7,7 +7,7 @@
 
 import cluster from 'cluster';
 import path from 'path';
-import { lock, unlock } from '../shared/locks';
+import { lock } from '../shared/locks';
 import fileExistsAsync from '../shared/fileExistsAsync';
 import log from '../shared/log';
 import {
@@ -84,18 +84,14 @@ async function handleNewBundleProvided(
 ): Promise<ResponseResult> {
   log.info('Worker received new bundle: %s', bundleFilePathPerTimestamp);
 
-  let lockAcquired = false;
-  let lockfileName: string | undefined;
+  // lock already catches errors internally, so it's safe to call without try/catch
+  const lockResult = await lock(bundleFilePathPerTimestamp);
   try {
-    const { lockfileName: name, wasLockAcquired, errorMessage } = await lock(bundleFilePathPerTimestamp);
-    lockfileName = name;
-    lockAcquired = wasLockAcquired;
-
-    if (!wasLockAcquired) {
+    if (!lockResult.wasLockAcquired) {
       const msg = formatExceptionMessage(
         renderingRequest,
-        errorMessage,
-        `Failed to acquire lock ${lockfileName}. Worker: ${workerIdLabel()}.`,
+        lockResult.error,
+        `Failed to acquire lock ${bundleFilePathPerTimestamp}. Worker: ${workerIdLabel()}.`,
       );
       return Promise.resolve(errorResponseResult(msg));
     }
@@ -143,17 +139,15 @@ to ${bundleFilePathPerTimestamp})`,
       return Promise.resolve(errorResponseResult(msg));
     }
   } finally {
-    if (lockAcquired) {
-      log.info('About to unlock %s from worker %i', lockfileName, workerIdLabel());
+    if (lockResult.wasLockAcquired) {
+      log.info('About to unlock %s from worker %i', bundleFilePathPerTimestamp, workerIdLabel());
       try {
-        if (lockfileName) {
-          await unlock(lockfileName);
-        }
+        await lockResult.release();
       } catch (error) {
         const msg = formatExceptionMessage(
           renderingRequest,
           error,
-          `Error unlocking ${lockfileName} from worker ${workerIdLabel()}.`,
+          `Error unlocking ${bundleFilePathPerTimestamp} from worker ${workerIdLabel()}.`,
         );
         log.warn(msg);
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1789,11 +1789,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/lockfile@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@types/lockfile/-/lockfile-1.0.4.tgz#9d6a6d1b6dbd4853cecc7f334bc53ea0ff363b8e"
-  integrity sha512-Q8oFIHJHr+htLrTXN2FuZfg+WXVHQRwU/hC2GpUu+Q8e3FUM9EDkS2pE3R2AO1ZGu56f479ybdMCNF1DAu8cAQ==
-
 "@types/mime@^1":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.5.tgz#1ef302e01cf7d2b5a0fa526790c9123bf1d06690"
@@ -1811,6 +1806,13 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.2.tgz#5950e50960793055845e956c427fc2b0d70c5239"
   integrity sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
 
+"@types/proper-lockfile@^4.1.4":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz#cd9fab92bdb04730c1ada542c356f03620f84008"
+  integrity sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==
+  dependencies:
+    "@types/retry" "*"
+
 "@types/qs@*":
   version "6.9.15"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.15.tgz#adde8a060ec9c305a82de1babc1056e73bd64dce"
@@ -1820,6 +1822,11 @@
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
+
+"@types/retry@*":
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.5.tgz#f090ff4bd8d2e5b940ff270ab39fd5ca1834a07e"
+  integrity sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==
 
 "@types/semver@^7.3.12":
   version "7.5.8"
@@ -5831,13 +5838,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lockfile@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.4.tgz#07f819d25ae48f87e538e6578b6964a4981a5609"
-  integrity sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==
-  dependencies:
-    signal-exit "^3.0.2"
-
 lodash.capitalize@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz#f826c9b4e2a8511d84e3aca29db05e1a4f3b72a9"
@@ -6789,6 +6789,15 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+proper-lockfile@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz#c8b9de2af6b2f1601067f98e01ac66baa223141f"
+  integrity sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    retry "^0.12.0"
+    signal-exit "^3.0.2"
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -7215,6 +7224,11 @@ retry@0.13.1:
   version "0.13.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
   integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
+
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==
 
 reusify@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
`proper-lockfile` has better API and [some improvements](https://www.npmjs.com/package/proper-lockfile#comparison). 

Once CI passes: 
1. need to check if it helps with locking errors in HiChee.
2. check with `TEST_LOCKFILE_THREADING`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Updated dependency packages to integrate a more reliable solution for managing resource locking.

- **Refactor**
  - Streamlined the internal resource locking process, improving error handling and operational stability.

- **Tests**
  - Modernized the testing approach to align with the new locking strategy, ensuring enhanced reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->