### PR TITLE
Revert httpx back to 1.3 for now

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ PATH
       addressable
       connection_pool
       execjs (~> 2.9)
-      httpx (~> 1.4, >= 1.4.2)
+      httpx (= 1.3.4)
       rainbow
       react_on_rails (>= 14.1.0)
 
@@ -154,7 +154,7 @@ GEM
       railties
     hashdiff (1.1.0)
     http-2 (1.0.2)
-    httpx (1.4.2)
+    httpx (1.3.4)
       http-2 (>= 1.0.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)

--- a/react_on_rails_pro.gemspec
+++ b/react_on_rails_pro.gemspec
@@ -30,7 +30,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "addressable"
   s.add_runtime_dependency "connection_pool"
   s.add_runtime_dependency "execjs", "~> 2.9"
-  s.add_runtime_dependency "httpx", "~> 1.4", ">= 1.4.2"
+  # 1.4.x runs into https://gitlab.com/os85/httpx/-/issues/340, upgrade when fixed
+  # (and switch from max_concurrent_requests to pool_options.max_connections_per_origin)
+  s.add_runtime_dependency "httpx", "1.3.4"
   s.add_runtime_dependency "rainbow"
   s.add_runtime_dependency "react_on_rails", ">= 14.1.0"
   s.add_development_dependency "bundler"


### PR DESCRIPTION
Due to https://gitlab.com/os85/httpx/-/issues/340.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted an underlying dependency to a stable release for enhanced reliability and to address compatibility concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->