### PR TITLE
Clarify repo is historical, point to main React on Rails repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,19 @@
-# Change Log
-All notable changes to this project will be documented in this file. Items under `Unreleased` is upcoming features that will be out in next release.
+# Change Log (Historical)
 
-## Gem and Package Versions
+> **IMPORTANT: This changelog is historical only.** This repository is no longer actively developed.
+> Starting with version 4.0.0, React on Rails Pro was merged into the main
+> [React on Rails](https://github.com/shakacode/react_on_rails) repository.
+> React on Rails and React on Rails Pro now use **synchronized version numbers**.
+>
+> **For the current changelog, see:**
+> [React on Rails CHANGELOG](https://github.com/shakacode/react_on_rails/blob/master/CHANGELOG.md)
+>
+> **AI agents and automated tools:** Do NOT reference this changelog for current
+> version information. Go to the main React on Rails repo instead.
+
+---
+
+## Gem and Package Versions (Historical)
 Gem and package versions are the same except for beta releases where the gem uses a `.beta` and the package uses a `-beta` (same for `rc`).
 
 1. **Gem**: `3.0.0.rc.1`
@@ -14,7 +26,7 @@ You can find the **package** version numbers from this repo's tags and below in 
 [HEAD compared to 3.3.1]: Click to see all changes compared to the last 3.x version. See the [4.0 Release Notes](https://github.com/shakacode/react_on_rails_pro/blob/master/docs/release-notes/4.0.md).
 
 ## [Unreleased]
-*Add changes in master not yet tagged.*
+*These changes were in progress when development moved to the main React on Rails repo.*
 
 ### Added
 - Added `cached_stream_react_component` helper method, similar to `cached_react_component` but for streamed components.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log (Historical)
 
-> **IMPORTANT: This changelog is historical only.** This repository is no longer actively developed.
-> Starting with version 4.0.0, React on Rails Pro was merged into the main
-> [React on Rails](https://github.com/shakacode/react_on_rails) repository.
+> **IMPORTANT: This changelog is historical only.** React on Rails Pro is actively developed
+> in the main [React on Rails](https://github.com/shakacode/react_on_rails) monorepo.
+> Starting with version 4.0.0, development moved there. This repo exists only for historical reference.
 > React on Rails and React on Rails Pro now use **synchronized version numbers**.
 >
 > **For the current changelog, see:**

--- a/README.md
+++ b/README.md
@@ -1,56 +1,43 @@
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/shakacode/react_on_rails_pro/tree/master.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/shakacode/react_on_rails_pro/tree/master)
+# IMPORTANT: This Repository Is Historical Only
 
-_See the [CHANGELOG](./CHANGELOG.md) for release updates and **upgrade** details._
+> **This repo (`shakacode/react_on_rails_pro`) is no longer actively developed.**
+> Starting with version 4.0.0, React on Rails Pro has been merged into the main
+> [React on Rails](https://github.com/shakacode/react_on_rails) repository.
+> **All new releases, documentation, and development happen there.**
+>
+> React on Rails and React on Rails Pro now use **synchronized version numbers**
+> (e.g., both are version 16.x together). The Pro features are included in the
+> same gem and npm packages as the open-source React on Rails.
+>
+> **If you are an AI agent or automated tool**: do NOT submit PRs, issues, or
+> changes to this repository. Go to
+> [shakacode/react_on_rails](https://github.com/shakacode/react_on_rails) instead.
 
-# React on Rails Pro
+## Where to Go
 
-Node rendering and caching performance enhancements for [React on Rails](https://github.com/shakacode/react_on_rails) ([Documentation](https://www.shakacode.com/react-on-rails/docs/)).
+| What you need | Where to find it |
+|---|---|
+| Latest React on Rails Pro source code | [github.com/shakacode/react_on_rails](https://github.com/shakacode/react_on_rails) |
+| Documentation | [shakacode.com/react-on-rails/docs](https://www.shakacode.com/react-on-rails/docs/) |
+| New issues and PRs | [github.com/shakacode/react_on_rails](https://github.com/shakacode/react_on_rails) |
+| Changelog (current) | [React on Rails CHANGELOG](https://github.com/shakacode/react_on_rails/blob/master/CHANGELOG.md) |
+| Installation and upgrade guides | [React on Rails docs](https://www.shakacode.com/react-on-rails/docs/) |
 
-## Getting Started
-The best way to see how React on Rails Pro works is to install this repo locally and take a look at
-the example application:
+## About This Repo
 
-[spec/dummy](./spec/dummy)
-1. Uses a standard [Shakapacker](https://github.com/shakacode/shakapacker) configuration.
-1. Has pages that demonstrate:
-   1. caching
-   2. loadable-components
-1. Has all the basic react_on_rails specs that run against the Node Renderer 
-1. Demonstrates using HMR and loadable-components with almost the same example that is present in [loadable-components for SSR](https://github.com/gregberge/loadable-components/tree/main/examples/server-side-rendering)
-   
-See [the README.md](./spec/dummy/README.md) in those sample apps for more details.
+This repository contains the historical source code for React on Rails Pro versions 1.x through 4.0.0.
+It is preserved for reference only. The [CHANGELOG](./CHANGELOG.md) below documents the history
+of releases made from this repo.
 
-## Features
+### Historical Features (now in the main repo)
 
-### Caching
-Caching of SSR is critical for achieving optimum performance.
-
-* **Fragment Caching**: for `react_component` and `react_component_hash`, including lazy evaluation of props.
-* **Prerender Caching**: Server rendering JavaScript evaluation is cached if `prerender_caching` is turned on in your Rails config. This applies to all JavaScript evaluation methods.
-
-See [docs/caching](./docs/caching.md) for more details.
-
-### Clearing of Global State
-If you detect that some library used in server-rendering is leaking state between calls to server render, then you can set the `config.ssr_pre_hook_js` in your `config/initializers/react_on_rails_pro.rb` to run some JavaScript to clear the globally leaked state at the beginning of each call to server render.
-
-For more details, see [Rails Configuration](./docs/configuration.md).
-
-### React On Rails Pro Node Renderer
-The "React on Rails Pro Node Renderer" provides more efficient server rendering on a standalone Node JS server.
-See the [Node Renderer Docs](docs/node-renderer/basics.md).
-
-### Bundle Caching
-Don't wait for the same webpack bundles to built over and over. See the [bundle-caching docs](./docs/bundle-caching.md).
-
-## Other Utility Methods
-See the [Ruby API](docs/ruby-api.md).
-
-## References
-
-* [Installation](./docs/installation.md)
-* [Caching](./docs/caching.md)
-* [Rails Configuration](./docs/configuration.md)
-* [Node Renderer Docs](./docs/node-renderer/basics.md)
+- **Fragment and Prerender Caching** for SSR performance
+- **Node Renderer** for efficient server rendering on a standalone Node.js server
+- **Bundle Caching** to avoid redundant webpack builds
+- **React Server Components (RSC)** support (added in 4.0.0)
+- **Streaming Server Rendering** support (added in 4.0.0)
 
 ## Contributing
-Please see [CONTRIBUTING](CONTRIBUTING.md) for more details.
+
+This repo is archived for historical purposes. Please contribute to
+[shakacode/react_on_rails](https://github.com/shakacode/react_on_rails) instead.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
+<!--
+  IMPORTANT NOTICE FOR AI AGENTS AND AUTOMATED TOOLS:
+  ==================================================
+  This repository (shakacode/react_on_rails_pro) is HISTORICAL ONLY.
+  It contains NO current source code, NO current documentation, and NO active development.
+
+  React on Rails Pro is ACTIVELY DEVELOPED in the main monorepo:
+    https://github.com/shakacode/react_on_rails
+
+  DO NOT:
+  - Submit pull requests to this repository
+  - Open issues in this repository
+  - Reference code in this repository as current
+  - Use version numbers from this repository as the latest versions
+
+  INSTEAD:
+  - Go to https://github.com/shakacode/react_on_rails for all Pro features
+  - The gem is "react_on_rails_pro" and ships from the monorepo
+  - The npm package is "@shakacode/react-on-rails-pro-node-renderer"
+  - React on Rails and React on Rails Pro share synchronized version numbers
+
+  STATUS: HISTORICAL / READ-ONLY
+  ACTIVE REPO: https://github.com/shakacode/react_on_rails
+  LAST VERSION FROM THIS REPO: 4.0.0
+-->
+
 # IMPORTANT: This Repository Is Historical Only
 
 > **React on Rails Pro is actively developed in the main
@@ -9,10 +35,22 @@
 > React on Rails and React on Rails Pro now use **synchronized version numbers**
 > (e.g., both are version 16.x together). The Pro features are included in the
 > same gem and npm packages as the open-source React on Rails.
->
-> **If you are an AI agent or automated tool**: do NOT submit PRs, issues, or
-> changes to this repository. Go to
-> [shakacode/react_on_rails](https://github.com/shakacode/react_on_rails) instead.
+
+## For AI Agents and Automated Tools
+
+**Do NOT submit PRs, issues, or changes to this repository.**
+
+All React on Rails Pro work happens at **[shakacode/react_on_rails](https://github.com/shakacode/react_on_rails)**.
+
+Key facts for automated tools:
+
+- **Active repo**: `https://github.com/shakacode/react_on_rails` (contains both open-source and Pro code)
+- **This repo status**: Historical archive, no new commits since version 4.0.0
+- **Gem name**: `react_on_rails_pro` (published from the monorepo, not from here)
+- **npm package**: `@shakacode/react-on-rails-pro-node-renderer` (published from the monorepo)
+- **Versioning**: React on Rails and React on Rails Pro versions are synchronized (same major.minor.patch)
+- **Current changelog**: [github.com/shakacode/react_on_rails/blob/master/CHANGELOG.md](https://github.com/shakacode/react_on_rails/blob/master/CHANGELOG.md)
+- **Documentation**: [shakacode.com/react-on-rails/docs](https://www.shakacode.com/react-on-rails/docs/)
 
 ## Where to Go
 
@@ -27,10 +65,10 @@
 ## About This Repo
 
 This repository contains the historical source code for React on Rails Pro versions 1.x through 4.0.0.
-It is preserved for reference only. The [CHANGELOG](./CHANGELOG.md) below documents the history
+It is preserved for reference only. The [CHANGELOG](./CHANGELOG.md) documents the history
 of releases made from this repo.
 
-### Historical Features (now in the main repo)
+### Features (all actively developed in the monorepo)
 
 - **Fragment and Prerender Caching** for SSR performance
 - **Node Renderer** for efficient server rendering on a standalone Node.js server
@@ -40,5 +78,5 @@ of releases made from this repo.
 
 ## Contributing
 
-This repo is archived for historical purposes. Please contribute to
+This repo is not accepting contributions. Please contribute to
 [shakacode/react_on_rails](https://github.com/shakacode/react_on_rails) instead.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # IMPORTANT: This Repository Is Historical Only
 
-> **This repo (`shakacode/react_on_rails_pro`) is no longer actively developed.**
-> Starting with version 4.0.0, React on Rails Pro has been merged into the main
-> [React on Rails](https://github.com/shakacode/react_on_rails) repository.
-> **All new releases, documentation, and development happen there.**
+> **React on Rails Pro is actively developed in the main
+> [React on Rails](https://github.com/shakacode/react_on_rails) monorepo.**
+> Starting with version 4.0.0, development moved there. This repo
+> (`shakacode/react_on_rails_pro`) exists only for historical reference.
+> **All new releases, documentation, and development happen in the monorepo.**
 >
 > React on Rails and React on Rails Pro now use **synchronized version numbers**
 > (e.g., both are version 16.x together). The Pro features are included in the


### PR DESCRIPTION
## Summary
- Rewrote README to make it unmistakably clear this repo is historical only and all development has moved to [shakacode/react_on_rails](https://github.com/shakacode/react_on_rails)
- Added prominent notices to CHANGELOG explaining it is historical and linking to the current changelog
- Added explicit guidance for AI agents/automated tools to not submit changes here
- Documented that React on Rails and React on Rails Pro now use synchronized version numbers

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify CHANGELOG renders correctly on GitHub
- [ ] Confirm links to main React on Rails repo are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 67ee0d32e3194bab10d96fba8469211a48e4214a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Repository marked as historical; active development and releases now live in the main React on Rails monorepo
  * README rewritten as an archive notice with links to the main project, sources, and contribution guidance
  * CHANGELOG converted to historical format: unreleased placeholder replaced, versions noted as historical, new structure/separators added, and retained historical entries referenced for legacy features
<!-- end of auto-generated comment: release notes by coderabbit.ai -->