### PR TITLE
[Bugfix] ScoutApm instrumentation load-order to match react_on_rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ You can find the **package** version numbers from this repo's tags and below in 
 ### Changed (Breaking)
 - `config.prerender_caching`, which controls caching for non-streaming components, now also controls caching for streamed components. To disable caching for an individual render, pass `internal_option(:skip_prerender_cache)`.
 
+### Fixed
+- **Fixed ScoutApm instrumentation depending on Gemfile ordering**. ScoutApm instrumentation for `exec_server_render_js` was previously installed at class load time using a `defined?(ScoutApm)` guard, which meant it was silently skipped if `scout_apm` appeared after `react_on_rails_pro` in the Gemfile. Moved instrumentation into an Engine initializer that runs after `scout_apm.start`, ensuring it works regardless of gem ordering and only after ScoutApm is fully configured. [PR 585](https://github.com/shakacode/react_on_rails_pro/pull/585) by [tonyta](https://github.com/tonyta).
+
 ## [4.0.0] - 2025-08-15
 
 ### Added

--- a/lib/react_on_rails_pro/engine.rb
+++ b/lib/react_on_rails_pro/engine.rb
@@ -7,5 +7,16 @@ module ReactOnRailsPro
     initializer "react_on_rails_pro.routes" do
       ActionDispatch::Routing::Mapper.include ReactOnRailsPro::Routes
     end
+
+    # Install ScoutApm instrumentation after ScoutApm is configured via "scout_apm.start" initializer.
+    # https://github.com/scoutapp/scout_apm_ruby/blob/v6.1.0/lib/scout_apm.rb#L221
+    initializer "react_on_rails_pro.scout_apm_instrumentation", after: "scout_apm.start" do
+      next unless defined?(ScoutApm)
+
+      ReactOnRailsPro::ServerRenderingPool::NodeRenderingPool.singleton_class.class_eval do
+        include ScoutApm::Tracer
+        instrument_method :exec_server_render_js, type: "ReactOnRails", name: "Node React Server Rendering"
+      end
+    end
   end
 end

--- a/lib/react_on_rails_pro/server_rendering_pool/node_rendering_pool.rb
+++ b/lib/react_on_rails_pro/server_rendering_pool/node_rendering_pool.rb
@@ -122,11 +122,6 @@ module ReactOnRailsPro
           fallback_renderer.instance_variable_set(:@js_context_pool, nil)
           result
         end
-
-        if defined?(ScoutApm)
-          include ScoutApm::Tracer
-          instrument_method :exec_server_render_js, type: "ReactOnRails", name: "Node React Server Rendering"
-        end
       end
     end
   end

--- a/spec/react_on_rails_pro/engine_spec.rb
+++ b/spec/react_on_rails_pro/engine_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+module ReactOnRailsPro
+  RSpec.describe Engine do
+    describe "ScoutApm instrumentation initializer" do
+      subject(:initializer) { described_class.initializers.find { |i| i.name.include?("scout_apm") } }
+
+      it "defines a named Rails initializer to run after scout_apm.start" do
+        expect(initializer.name).to eq "react_on_rails_pro.scout_apm_instrumentation"
+        expect(initializer.after).to eq "scout_apm.start"
+      end
+
+      describe "react_on_rails_pro.scout_apm_instrumentation" do
+        let(:mock_scout_tracer) do
+          # Simplified mock of ScoutApm::Tracer that mirrors its real implementation.
+          # https://github.com/scoutapp/scout_apm_ruby/blob/v6.1.0/lib/scout_apm/tracer.rb#L47-L70
+          Module.new do
+            def self.included(base)
+              base.define_singleton_method(:instrument_method) do |method_name, **|
+                raise "method does not exist: #{method_name}" unless method_defined?(method_name)
+
+                instrumented_name = :"#{method_name}_with_test_instrument"
+                uninstrumented_name = :"#{method_name}_without_test_instrument"
+
+                define_method(instrumented_name) do |*args, **kwargs, &block|
+                  send(uninstrumented_name, *args, **kwargs, &block)
+                end
+
+                alias_method uninstrumented_name, method_name
+                alias_method method_name, instrumented_name
+              end
+            end
+          end
+        end
+
+        let(:mock_node_rendering_pool) do
+          Class.new(ReactOnRailsPro::ServerRenderingPool::NodeRenderingPool)
+        end
+
+        before do
+          stub_const("ReactOnRailsPro::ServerRenderingPool::NodeRenderingPool", mock_node_rendering_pool)
+        end
+
+        context "when ScoutApm is not defined" do
+          before { hide_const("ScoutApm") }
+
+          it "does not instrument NodeRenderingPool.exec_server_render_js" do
+            initializer.run
+            expect(mock_node_rendering_pool.methods(false)).not_to include(:exec_server_render_js_with_test_instrument)
+            expect(mock_node_rendering_pool.methods(false)).not_to include(:exec_server_render_js_without_test_instrument)
+          end
+        end
+
+        context "when ScoutApm is defined" do
+          before { stub_const("ScoutApm::Tracer", mock_scout_tracer) }
+
+          it "instruments NodeRenderingPool.exec_server_render_js" do
+            initializer.run
+            expect(mock_node_rendering_pool.methods(false)).to include(:exec_server_render_js_with_test_instrument)
+            expect(mock_node_rendering_pool.methods(false)).to include(:exec_server_render_js_without_test_instrument)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit moves the instrumentation loading into ReactOnRails::Engine with an initializer explicitly configured to run after ScoutApm initializes ("scout_apm.start"). This ensures instrumentation is properly installed regardless of gem ordering and only after ScoutApm is fully configured.

This mirrors the fix in the core gem (shakacode/react_on_rails#2442).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured performance monitoring initialization for server-side rendering operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->