### PR TITLE
Redirect new issues to the react_on_rails monorepo (repo is historical)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🚫 This repository is historical — do not open issues here
+    url: https://github.com/shakacode/react_on_rails/issues/new/choose
+    about: react_on_rails_pro is read-only (historical, versions 1.x–4.0.0). React on Rails Pro is now developed in the shakacode/react_on_rails monorepo. Please open all issues there.
+  - name: 📦 React on Rails monorepo (active development)
+    url: https://github.com/shakacode/react_on_rails
+    about: All current code, docs, releases, and issues for React on Rails and React on Rails Pro live here.


### PR DESCRIPTION
## What

Adds `.github/ISSUE_TEMPLATE/config.yml` that disables blank issues and redirects anyone trying to open an issue here to the active `shakacode/react_on_rails` monorepo.

## Why

This repository is historical/read-only (the README already says so prominently), but **issue creation was still enabled with no redirect** — so issues still land here by mistake, including from automated tools that don't read the README. This change makes the "don't use this repo" intent enforced at the point of issue creation: the "New issue" button now shows only links to the monorepo instead of a blank issue form.

This is a soft guard (it doesn't fully disable the Issues tab — that's a repo setting). If you want a hard stop, disable Issues in repo settings; archiving would be the further step.

---

AI disclosure: created with Claude Opus 4.8 (Claude Code), after mistakenly filing three issues here that belonged in the monorepo.
